### PR TITLE
chore: use fin de dia script in workflow

### DIFF
--- a/.github/workflows/fetch_calair_ayer.yml
+++ b/.github/workflows/fetch_calair_ayer.yml
@@ -2,7 +2,7 @@ name: Fetch calair (ayer)
 
 on:
   schedule:
-    - cron: '15 6 * * *'  # 06:15 UTC diario (~08:15 Madrid)
+    - cron: '30 1 * * *'  # 01:30 UTC diario (~03:30 Madrid)
   workflow_dispatch:
 
 jobs:
@@ -20,11 +20,12 @@ jobs:
       - name: Install deps
         run: |
           python -m pip install --upgrade pip
-          pip install certifi
+          pip install certifi requests
 
-      - name: Run script (ayer)
+      - name: Run script (fin de día)
         run: |
-          python scripts/fetch_calair_ayer.py
+          YESTERDAY=$(date -u -d 'yesterday' +%F)
+          python scripts/fetch_calair_fin_dia.py --date "$YESTERDAY"
 
       - name: Commit & push if changes
         run: |

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # Datasets
 Dataset catalogue
+
+## Flujos automatizados
+
+- `fetch_calair_ayer.yml`: descarga diariamente los datos de CalAIR del día
+  anterior ejecutando `fetch_calair_fin_dia.py`. Se programa a las **01:30 UTC**
+  (≈03:30 Madrid) una vez cerrado el día y **antes** del flujo de subida a GCP.
+- `calair_fin_dia_to_gcs.yml`: publica el último `.flat.csv` en GCS a las
+  **02:15 UTC** (≈04:15 Madrid).


### PR DESCRIPTION
## Summary
- fetch previous-day CalAIR data with `fetch_calair_fin_dia.py` in dedicated workflow
- install `requests` and document new daily schedule relative to GCP upload

## Testing
- `python -m py_compile scripts/fetch_calair_fin_dia.py`

------
https://chatgpt.com/codex/tasks/task_e_68b1bca765588332a239ab0a18b000c7