### PR TITLE
Check CalAIR data dir before uploading to GCS

### DIFF
--- a/.github/workflows/calair_fin_dia_to_gcs.yml
+++ b/.github/workflows/calair_fin_dia_to_gcs.yml
@@ -50,7 +50,11 @@ jobs:
             TARGET_DIR="data/calair/${{ github.event.inputs.date }}"
           else
             python ./scripts/fetch_calair_fin_dia.py
-            TARGET_DIR=$(ls -dt data/calair/*/ | head -n1 | sed 's:/$::')
+            TARGET_DIR=$(find data/calair -mindepth 1 -maxdepth 1 -type d -printf '%T@ %p\n' | sort -nr | head -n1 | cut -d' ' -f2-)
+            if [ -z "$TARGET_DIR" ]; then
+              echo "❌ No se encontró ningún directorio en data/calair/"
+              exit 1
+            fi
           fi
           echo "TARGET_DIR=$TARGET_DIR" >> $GITHUB_ENV
           echo "Contenido de $TARGET_DIR:"


### PR DESCRIPTION
## Summary
- Ensure the CalAIR fin de día workflow fails early when no output directory is found

## Testing
- `yamllint .github/workflows/calair_fin_dia_to_gcs.yml` *(fails: command not found)*
- `pip install yamllint` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b1bfd50b14833280022d8c4a57f7fa