### PR TITLE
fix: define schedule in fetch-calair workflow

### DIFF
--- a/.github/workflows/fetch-calair.yml
+++ b/.github/workflows/fetch-calair.yml
@@ -1,10 +1,11 @@
 name: Fetch calair_tiemporeal (daily)
 
 on:
-  # Arranca a las 23:00 Madrid y repite cada 15 min hasta ~01:45
-  # Notas de huso horario: definimos dos ventanas (verano/invierno) en UTC
-  - cron: "0,15,30,45 21,22,23 * * *"   # 23:00→01:45 Madrid en verano (UTC+2)
-  - cron: "0,15,30,45 22,23,0 * * *"    # 23:00→01:45 Madrid en invierno (UTC+1)
+  schedule:
+    # Arranca a las 23:00 Madrid y repite cada 15 min hasta ~01:45
+    # Notas de huso horario: definimos dos ventanas (verano/invierno) en UTC
+    - cron: "0,15,30,45 21,22,23 * * *"   # 23:00→01:45 Madrid en verano (UTC+2)
+    - cron: "0,15,30,45 22,23,0 * * *"    # 23:00→01:45 Madrid en invierno (UTC+1)
   workflow_dispatch:
     inputs:
       max_retries:


### PR DESCRIPTION
## Summary
- fix fetch-calair workflow schedule definition

## Testing
- `yamllint .github/workflows/fetch-calair.yml` *(fails: command not found)*
- `pip install yamllint` *(fails: Could not find a version that satisfies the requirement yamllint)*

------
https://chatgpt.com/codex/tasks/task_e_68c75562451083329169b2c5b87158b3