### PR TITLE
Fix fetch-calair workflow YAML syntax

### DIFF
--- a/.github/workflows/fetch-calair.yml
+++ b/.github/workflows/fetch-calair.yml
@@ -1,9 +1,7 @@
 name: Fetch calair_tiemporeal (daily)
 
-on:
+'on':
   schedule:
-    # Arranca a las 23:00 Madrid y repite cada 15 min hasta ~01:45
-    # Notas de huso horario: definimos dos ventanas (verano/invierno) en UTC
     - cron: "0,15,30,45 21,22,23 * * *"   # 23:00→01:45 Madrid en verano (UTC+2)
     - cron: "0,15,30,45 22,23,0 * * *"    # 23:00→01:45 Madrid en invierno (UTC+1)
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- fix fetch-calair workflow YAML syntax by quoting `on` and removing unsupported comments

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c756d31e4c83329ce4c4af8d6c6ef1