### PR TITLE
Fix fetch-calair workflow YAML syntax and shorten retries

### DIFF
--- a/.github/workflows/fetch-calair.yml
+++ b/.github/workflows/fetch-calair.yml
@@ -1,24 +1,23 @@
 name: Fetch calair_tiemporeal (daily)
 
-on:
+'on':
   schedule:
-    # Arranca a las 23:00 Madrid y repite cada 15 min hasta ~01:45
-    # Notas de huso horario: definimos dos ventanas (verano/invierno) en UTC
     - cron: "0,15,30,45 21,22,23 * * *"   # 23:00→01:45 Madrid en verano (UTC+2)
     - cron: "0,15,30,45 22,23,0 * * *"    # 23:00→01:45 Madrid en invierno (UTC+1)
   workflow_dispatch:
     inputs:
       max_retries:
-        description: "CALAIR_MAX_RETRIES (default 2)"
+        description: "CALAIR_MAX_RETRIES (default 1)"
         required: false
-        default: "2"
+        default: "1"
       wait_seconds:
-        description: "CALAIR_WAIT_SECONDS (default 180)"
+        description: "CALAIR_WAIT_SECONDS (default 60)"
         required: false
-        default: "180"
+        default: "60"
 
 jobs:
   fetch-and-commit:
+    timeout-minutes: 7
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -53,8 +52,8 @@ jobs:
         run: |
           set -e
           # Reintentos y espera configurables (inputs -> env)
-          export CALAIR_MAX_RETRIES="${{ github.event.inputs.max_retries || '2' }}"
-          export CALAIR_WAIT_SECONDS="${{ github.event.inputs.wait_seconds || '180' }}"
+          export CALAIR_MAX_RETRIES="${{ github.event.inputs.max_retries || '1' }}"
+          export CALAIR_WAIT_SECONDS="${{ github.event.inputs.wait_seconds || '60' }}"
           python scripts/fetch_calair.py
 
       - name: List output files

--- a/scripts/fetch_calair.py
+++ b/scripts/fetch_calair.py
@@ -314,8 +314,8 @@ def main() -> int:
     latest_flat_csv  = day_dir / "latest.flat.csv"
 
     # 1) Descarga datos tiempo real con reintentos si el CSV plano queda vacío
-    max_retries = int((os.getenv("CALAIR_MAX_RETRIES") or "2").strip() or 2)
-    wait_seconds = int((os.getenv("CALAIR_WAIT_SECONDS") or "180").strip() or 180)
+    max_retries = int((os.getenv("CALAIR_MAX_RETRIES") or "1").strip() or 1)
+    wait_seconds = int((os.getenv("CALAIR_WAIT_SECONDS") or "60").strip() or 60)
     attempt = 0
     last_err: Exception | None = None
     payload = None


### PR DESCRIPTION
## Summary
- fix fetch-calair workflow YAML syntax by quoting `on` and removing unsupported comments
- reduce retry count and wait defaults in `fetch-calair` workflow, add job timeout, and align script defaults

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c756d31e4c83329ce4c4af8d6c6ef1